### PR TITLE
Send the block immediatly to the bottom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,18 @@
         <version.plugin.maven.enforcer>3.0.0</version.plugin.maven.enforcer>
         <version.plugin.maven.surefire>3.0.0-M5</version.plugin.maven.surefire>
         <version.plugin.maven.jar>3.2.0</version.plugin.maven.jar>
+        <version.jnativehook>2.2.1</version.jnativehook>
         <version.testng>7.5</version.testng>
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.github.kwhat</groupId>
+            <artifactId>jnativehook</artifactId>
+            <version>${version.jnativehook}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.epam.prejap</groupId>
     <artifactId>tea-trees</artifactId>
-    <version>0.6</version>
+    <version>0.7</version>
 
     <properties>
         <version.java>17</version.java>

--- a/src/main/java/com/epam/prejap/teatrees/block/BlockFeed.java
+++ b/src/main/java/com/epam/prejap/teatrees/block/BlockFeed.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 public class BlockFeed {
 
     private final Random rnd = new Random();
-    private final List<Supplier<Block>> blocks = List.of(
+    protected final List<Supplier<Block>> blocks = List.of(
             OBlock::new, ZBlock::new
     );
 

--- a/src/main/java/com/epam/prejap/teatrees/game/Playfield.java
+++ b/src/main/java/com/epam/prejap/teatrees/game/Playfield.java
@@ -9,7 +9,7 @@ import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
 
 public class Playfield {
 
-    private final byte[][] grid;
+    final byte[][] grid;
     private final int rows;
     private final int cols;
     private final Printer printer;
@@ -18,7 +18,7 @@ public class Playfield {
     private Block block;
     private int row;
     private int col;
-    private boolean downArrowPressed;
+    boolean downArrowPressed;
 
     public Playfield(int rows, int cols, BlockFeed feed, Printer printer) {
         this.rows = rows;

--- a/src/test/java/com/epam/prejap/teatrees/game/PlayFieldTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/game/PlayFieldTest.java
@@ -1,0 +1,70 @@
+package com.epam.prejap.teatrees.game;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import com.epam.prejap.teatrees.block.Block;
+import com.epam.prejap.teatrees.block.BlockFeed;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+public class PlayFieldTest {
+    private byte[][] expectedGridAfterFirstBlock;
+    private byte[][] expectedGridAfterKeyDown;
+    private byte[][] expectedGridAfterSecondBlock;
+    private ByteArrayOutputStream consoleContent = new ByteArrayOutputStream();
+    
+    @BeforeTest
+    void BeforeTest() {
+        expectedGridAfterFirstBlock = new byte[][] {
+                { 0, 0, 1, 1, 0, 0, },
+                { 0, 0, 1, 1, 0, 0, },
+                { 0, 0, 0, 0, 0, 0, },
+                { 0, 0, 0, 0, 0, 0, },
+                { 0, 0, 0, 0, 0, 0, },
+        };
+        expectedGridAfterKeyDown = new byte[][] {
+                { 0, 0, 0, 0, 0, 0, },
+                { 0, 0, 0, 0, 0, 0, },
+                { 0, 0, 0, 0, 0, 0, },
+                { 0, 0, 1, 1, 0, 0, },
+                { 0, 0, 1, 1, 0, 0, },
+        };
+        expectedGridAfterSecondBlock = new byte[][] {
+                { 0, 0, 1, 1, 0, 0, },
+                { 0, 0, 1, 1, 0, 0, },
+                { 0, 0, 0, 0, 0, 0, },
+                { 0, 0, 1, 1, 0, 0, },
+                { 0, 0, 1, 1, 0, 0, },
+        };
+    }
+
+
+    @Test(groups = "bottom-move-test")
+    public void testBottomMove() {
+        Playfield playfield = new Playfield(5, 6, new TestBlockFeed(), new Printer(new PrintStream(this.consoleContent)));
+        SoftAssert sa = new SoftAssert();
+
+        playfield.nextBlock();
+        sa.assertEquals(playfield.grid, expectedGridAfterFirstBlock);
+
+        playfield.downArrowPressed = true;
+        playfield.move(Move.NONE);
+        sa.assertEquals(playfield.grid, expectedGridAfterKeyDown);
+
+        playfield.nextBlock();
+        sa.assertEquals(playfield.grid, expectedGridAfterSecondBlock);
+
+        sa.assertAll();
+    }
+
+    class TestBlockFeed extends BlockFeed {
+        @Override
+        public Block nextBlock() {
+            return blocks.get(0).get();
+        }
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -53,5 +53,17 @@
             <class name="com.epam.prejap.teatrees.block.ZBlockTest" />
         </classes>
     </test>
-    
+    <test name="bottomMove">
+        <groups>
+            <define name="bottom-move-test">
+                <include name="allWayDown"/>
+            </define>
+            <run>
+                <include name="bottom-move-test" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.epam.prejap.teatrees.game.PlayfieldTest"></class>
+        </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Adds the possibility of moving the block immediately to the bottom when the user presses the DOWN key. To test this feature, some private fields had to be changed to package-private or protected.
Closes #18 