### PR TITLE
9 rotation of blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.epam.prejap</groupId>
     <artifactId>tea-trees</artifactId>
-    <version>0.9</version>
+    <version>0.10</version>
 
     <properties>
         <version.java>17</version.java>

--- a/src/main/java/com/epam/prejap/teatrees/block/RotatedBlock.java
+++ b/src/main/java/com/epam/prejap/teatrees/block/RotatedBlock.java
@@ -1,0 +1,18 @@
+package com.epam.prejap.teatrees.block;
+
+/**
+ * @author Krzysztof Janas
+ */
+public final class RotatedBlock extends Block {
+    public RotatedBlock(Block block) {
+        super(rotatedDots(block));
+    }
+
+    private static byte[][] rotatedDots(Block block) {
+        byte[][] dots = new byte[block.cols()][block.rows()];
+        for (int i = 0; i < block.cols(); i++)
+            for (int j = 0; j < block.rows(); j++)
+                dots[i][j] = block.dotAt(block.rows - j - 1, i);
+        return dots;
+    }
+}

--- a/src/main/java/com/epam/prejap/teatrees/block/RotatedBlock.java
+++ b/src/main/java/com/epam/prejap/teatrees/block/RotatedBlock.java
@@ -1,9 +1,19 @@
 package com.epam.prejap.teatrees.block;
 
 /**
+ * Clockwise rotation for blocks in Tetris game.
+ *
  * @author Krzysztof Janas
+ * @see Block
  */
 public final class RotatedBlock extends Block {
+    /**
+     * Create new Block that is rotated version of given block.
+     *
+     * The given block is not modified.
+     *
+     * @param block to rotate
+     */
     public RotatedBlock(Block block) {
         super(rotatedDots(block));
     }

--- a/src/main/java/com/epam/prejap/teatrees/block/ZBlock.java
+++ b/src/main/java/com/epam/prejap/teatrees/block/ZBlock.java
@@ -6,13 +6,13 @@ package com.epam.prejap.teatrees.block;
  * @author Jovhar Isayev
  * @see Block
  */
-final class ZBlock extends Block {
+public final class ZBlock extends Block {
     private static final byte[][] IMAGE = new byte[][]{
             {1, 1, 0},
             {0, 1, 1}
     };
 
-    ZBlock() {
+    public ZBlock() {
         super(IMAGE);
     }
 }

--- a/src/main/java/com/epam/prejap/teatrees/block/ZBlock.java
+++ b/src/main/java/com/epam/prejap/teatrees/block/ZBlock.java
@@ -6,13 +6,13 @@ package com.epam.prejap.teatrees.block;
  * @author Jovhar Isayev
  * @see Block
  */
-public final class ZBlock extends Block {
+final class ZBlock extends Block {
     private static final byte[][] IMAGE = new byte[][]{
             {1, 1, 0},
             {0, 1, 1}
     };
 
-    public ZBlock() {
+    ZBlock() {
         super(IMAGE);
     }
 }

--- a/src/main/java/com/epam/prejap/teatrees/game/Move.java
+++ b/src/main/java/com/epam/prejap/teatrees/game/Move.java
@@ -5,6 +5,7 @@ public enum Move {
     NONE(' '),
     LEFT('h'),
     RIGHT('l'),
+    UP('k')
     ;
 
     private final int key;

--- a/src/main/java/com/epam/prejap/teatrees/game/Playfield.java
+++ b/src/main/java/com/epam/prejap/teatrees/game/Playfield.java
@@ -2,6 +2,7 @@ package com.epam.prejap.teatrees.game;
 
 import com.epam.prejap.teatrees.block.Block;
 import com.epam.prejap.teatrees.block.BlockFeed;
+import com.epam.prejap.teatrees.block.RotatedBlock;
 
 public class Playfield {
 
@@ -39,8 +40,9 @@ public class Playfield {
         hide();
         boolean moved;
         switch (move) {
-            case LEFT -> moveLeft();
+            case LEFT  -> moveLeft();
             case RIGHT -> moveRight();
+            case UP    -> rotate();
         }
         moved = moveDown();
         show();
@@ -66,6 +68,12 @@ public class Playfield {
             moved = true;
         }
         return moved;
+    }
+
+    private void rotate() {
+        Block rotated = new RotatedBlock(block);
+        if (isValidMove(block, 0, 0))
+            block = rotated;
     }
 
     private boolean isValidMove(Block block, int rowOffset, int colOffset) {

--- a/src/main/java/com/epam/prejap/teatrees/game/Playfield.java
+++ b/src/main/java/com/epam/prejap/teatrees/game/Playfield.java
@@ -6,15 +6,15 @@ import com.epam.prejap.teatrees.block.RotatedBlock;
 
 public class Playfield {
 
-    private final Grid grid;
     private final int rows;
     private final int cols;
     private final Printer printer;
     private final BlockFeed feed;
 
-    private Block block;
-    private int row;
-    private int col;
+    final Grid grid;
+    Block block;
+    int row;
+    int col;
 
     public Playfield(int rows, int cols, BlockFeed feed, Printer printer) {
         this.rows = rows;
@@ -36,6 +36,22 @@ public class Playfield {
         show();
     }
 
+    /**
+     * Perform move for current block if possible
+     * (there is place for the block after move).
+     *
+     * After each move, the block is shifted down one unit (if possible).
+     *
+     * Possible moves:
+     * <ul>
+     * <li>LEFT - move block one unit left;</li>
+     * <li>RIGHT - move block one unit right;</li>
+     * <li>UP - rotate block clockwise.</li>
+     * </ul>
+     *
+     * @param move action for current block
+     * @return true if the current block was moved down
+     */
     public boolean move(Move move) {
         hide();
         boolean moved;
@@ -72,7 +88,7 @@ public class Playfield {
 
     private void rotate() {
         Block rotated = new RotatedBlock(block);
-        if (isValidMove(block, 0, 0))
+        if (isValidMove(rotated, 0, 0))
             block = rotated;
     }
 

--- a/src/test/java/com/epam/prejap/teatrees/block/MockedBlock.java
+++ b/src/test/java/com/epam/prejap/teatrees/block/MockedBlock.java
@@ -1,0 +1,12 @@
+package com.epam.prejap.teatrees.block;
+
+/**
+ * Mocked frame for testing blocks that is used by tests only
+ *
+ * @author Krzysztof Janas
+ */
+public class MockedBlock extends Block {
+    public MockedBlock(byte[][] dots) {
+        super(dots);
+    }
+}

--- a/src/test/java/com/epam/prejap/teatrees/block/RotatedBlockTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/block/RotatedBlockTest.java
@@ -53,6 +53,7 @@ public class RotatedBlockTest {
         return new Object[][]{
                 { new OBlock() },
                 { new ZBlock() },
+                { new RotatedBlock(new ZBlock()) },
                 { line },
                 { axe },
                 { colors },
@@ -84,6 +85,7 @@ public class RotatedBlockTest {
         return new Object[][]{
                 { new OBlock(), new OBlock() },
                 { new ZBlock(), new MockedBlock(new byte[][]{{0, 1}, {1, 1}, {1, 0}}) },
+                { new RotatedBlock(new ZBlock()), new ZBlock() },
                 { line,   new MockedBlock(new byte[][]{{1}, {1}, {1}, {1}, {1}}) },
                 { axe,    new MockedBlock(new byte[][]{{1, 0, 1}, {1, 1, 0}, {1, 0, 1}, {1, 0, 0}}) },
                 { colors, new MockedBlock(new byte[][]{{4, 1}, {5, 2}, {6, 3}})},

--- a/src/test/java/com/epam/prejap/teatrees/block/RotatedBlockTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/block/RotatedBlockTest.java
@@ -1,0 +1,126 @@
+package com.epam.prejap.teatrees.block;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+import java.util.Random;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "blocks")
+public class RotatedBlockTest {
+    private void assertEqualsBlocks(Block actual, Block expected) {
+        assertEquals(actual.rows(), expected.rows());
+        assertEquals(actual.cols(), expected.cols());
+
+        SoftAssert sa = new SoftAssert();
+        for (int i = 0; i < actual.rows(); i++)
+            for (int j = 0; j < actual.cols(); j++) {
+                sa.assertEquals(actual.dotAt(i, j), expected.dotAt(i, j),
+                        String.format("Dot mismatch for [%d][%d]: actual = %d, expected = %d",
+                                i, j, actual.dotAt(i, j), expected.dotAt(i, j)));
+            }
+        sa.assertAll();
+    }
+
+    @Test
+    public void rotationDoesNotModifyOriginalBlock() {
+        // given
+        Block testBlock = new ZBlock();
+        Block baseBlock = new ZBlock();
+        // when
+        new RotatedBlock(testBlock);
+        // then
+        assertEqualsBlocks(testBlock, baseBlock);
+    }
+
+    private static class MockedBlock extends Block {
+        MockedBlock(byte[][] dots) {
+            super(dots);
+        }
+    }
+
+    private static final MockedBlock line   = new MockedBlock(new byte[][]{{1, 1, 1, 1}});
+    private static final MockedBlock axe    = new MockedBlock(new byte[][]{{1, 0, 1, 0},
+                                                                           {0, 1, 0, 0},
+                                                                           {1, 1, 1, 1}});
+    private static final MockedBlock colors = new MockedBlock(new byte[][]{{1, 2, 3},
+                                                                           {4, 5, 6}});
+
+    @DataProvider
+    public static Object[][] rotatableBlocks() {
+        return new Object[][]{
+                { new OBlock() },
+                { new ZBlock() },
+                { line },
+                { axe },
+                { colors },
+        };
+    }
+
+    @Test(dataProvider = "rotatableBlocks")
+    public void rotatedRowsEqualsInitialCols(Block block) {
+        // given
+        int initialCols = block.cols();
+        // when
+        int rotatedRows = new RotatedBlock(block).rows();
+        // then
+        assertEquals(rotatedRows, initialCols);
+    }
+
+    @Test(dataProvider = "rotatableBlocks")
+    public void rotatedColsEqualsInitialRows(Block block) {
+        // given
+        int initialRows = block.rows();
+        // when
+        int rotatedCols = new RotatedBlock(block).cols();
+        // then
+        assertEquals(rotatedCols, initialRows);
+    }
+
+    @DataProvider
+    public static Object[][] rotatableBlocksWithRotations() {
+        return new Object[][]{
+                { new OBlock(), new OBlock() },
+                { new ZBlock(), new MockedBlock(new byte[][]{{0, 1}, {1, 1}, {1, 0}}) },
+                { line,   new MockedBlock(new byte[][]{{1}, {1}, {1}, {1}, {1}}) },
+                { axe,    new MockedBlock(new byte[][]{{1, 0, 1}, {1, 1, 0}, {1, 0, 1}, {1, 0, 0}}) },
+                { colors, new MockedBlock(new byte[][]{{4, 1}, {5, 2}, {6, 3}})},
+        };
+    }
+
+    @Test(dataProvider = "rotatableBlocks")
+    public void fourRotationsTogetherEqualsInitial(Block block) {
+        // given
+        Block testBlock = block;
+        // when
+        for(int i = 0; i < 4; ++i)
+            testBlock = new RotatedBlock(testBlock);
+        // then
+        assertEqualsBlocks(testBlock, block);
+    }
+
+    private static class RandomBlock extends Block {
+        RandomBlock() {
+            super(randomDots());
+        }
+
+        private static byte[][] randomDots() {
+            Random rand = new Random();
+            int rows = rand.nextInt(1, 6);
+            int cols = rand.nextInt(1, 6);
+            byte[][] dots = new byte[rows][cols];
+            for (int i = 0; i < rows; i++)
+                for (int j = 0; j < cols; j++)
+                    dots[i][j] = (byte)rand.nextInt(5);
+            return dots;
+        }
+    }
+
+    @Test(dependsOnMethods = "fourRotationsTogetherEqualsInitial")
+    public void fourRotationsTogetherEqualsInitialRandom() {
+        for(int i = 0; i < 1000; ++i)
+            fourRotationsTogetherEqualsInitial(new RandomBlock());
+    }
+}

--- a/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
@@ -62,11 +62,11 @@ public class PlayfieldTest {
                                          {0, 0, 0, 0, 0},  // {0, 0, 1, 1, 0}
                                          {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
 
-        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 0},
-                                         {0, 0, 1, 0, 0},
-                                         {0, 1, 1, 0, 0},
-                                         {0, 1, 0, 0, 0}};
+        var expectedGrid  = new Grid(new byte[][]{{0, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 0},
+                                                  {0, 0, 1, 0, 0},
+                                                  {0, 1, 1, 0, 0},
+                                                  {0, 1, 0, 0, 0}});
 
         Block block = new ZBlock();
 
@@ -96,18 +96,18 @@ public class PlayfieldTest {
                                          {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
                                          {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
         
-        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
-                                         {0, 1, 0, 0, 0},
-                                         {1, 1, 0, 0, 0},
-                                         {1, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 0}};
+        var expectedGrid  = new Grid(new byte[][]{{0, 0, 0, 0, 0},
+                                                  {0, 1, 0, 0, 0},
+                                                  {1, 1, 0, 0, 0},
+                                                  {1, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 0}});
 
         Block block = new ZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
         playfield.row   = 0;
-        playfield.col   = 1;
+        playfield.col   = 0;
 
         // when
         boolean movedDown = playfield.move(Move.UP);
@@ -116,7 +116,7 @@ public class PlayfieldTest {
         SoftAssert sa = new SoftAssert();
         sa.assertTrue(movedDown);
         sa.assertEquals(playfield.row, 1);
-        sa.assertEquals(playfield.col, 1);
+        sa.assertEquals(playfield.col, 0);
         sa.assertTrue(playfield.block instanceof RotatedBlock);
         sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
@@ -130,11 +130,11 @@ public class PlayfieldTest {
                                          {2, 0, 2, 2, 2},  // {2, 0, 2, 2, 2}
                                          {2, 2, 2, 2, 2}}; // {2, 2, 2, 2, 2}
         
-        var expectedGrid  = new byte[][]{{2, 2, 2, 2, 2},
-                                         {2, 0, 1, 2, 2},
-                                         {2, 1, 1, 0, 2},
-                                         {2, 1, 2, 2, 2},
-                                         {2, 2, 2, 2, 2}};
+        var expectedGrid  = new Grid(new byte[][]{{2, 2, 2, 2, 2},
+                                                  {2, 0, 1, 2, 2},
+                                                  {2, 1, 1, 0, 2},
+                                                  {2, 1, 2, 2, 2},
+                                                  {2, 2, 2, 2, 2}});
 
         Block block = new ZBlock();
 
@@ -164,11 +164,11 @@ public class PlayfieldTest {
                                          {0, 0, 0, 0, 0},  // {0, 1, 1, 0, 0}
                                          {0, 0, 0, 0, 0}}; // {0, 0, 1, 1, 0}
 
-        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 0},
-                                         {0, 1, 1, 0, 0},
-                                         {0, 0, 1, 1, 0}};
+        var expectedGrid  = new Grid(new byte[][]{{0, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 0},
+                                                  {0, 1, 1, 0, 0},
+                                                  {0, 0, 1, 1, 0}});
 
         Block block = new ZBlock();
 
@@ -198,11 +198,11 @@ public class PlayfieldTest {
                                          {0, 0, 0, 0, 0},  // {0, 0, 0, 1, 0}
                                          {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
 
-        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 1},
-                                         {0, 0, 0, 1, 1},
-                                         {0, 0, 0, 1, 0}};
+        var expectedGrid  = new Grid(new byte[][]{{0, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 1},
+                                                  {0, 0, 0, 1, 1},
+                                                  {0, 0, 0, 1, 0}});
 
         Block block = new RotatedBlock(new ZBlock());
 
@@ -232,11 +232,11 @@ public class PlayfieldTest {
                                          {2, 2, 2, 2, 2},  // {2, 0, 2, 2, 2}
                                          {2, 2, 2, 2, 2}}; // {2, 2, 2, 2, 2}
 
-        var expectedGrid  = new byte[][]{{2, 2, 2, 2, 2},
-                                         {2, 1, 1, 2, 2},
-                                         {2, 0, 1, 1, 2},
-                                         {2, 2, 2, 2, 2},
-                                         {2, 2, 2, 2, 2}};
+        var expectedGrid  = new Grid(new byte[][]{{2, 2, 2, 2, 2},
+                                                  {2, 1, 1, 2, 2},
+                                                  {2, 0, 1, 1, 2},
+                                                  {2, 2, 2, 2, 2},
+                                                  {2, 2, 2, 2, 2}});
 
         Block block = new ZBlock();
 

--- a/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
@@ -15,7 +15,8 @@ public class PlayfieldTest {
         BlockFeed blockFeed = new BlockFeed();
         Playfield playfield = new Playfield(grid.length, grid[0].length, blockFeed, printer);
         for(int i = 0; i < grid.length; ++i)
-            System.arraycopy(grid[i], 0, playfield.grid[i], 0, grid[0].length);
+            for(int j = 0; j < grid[0].length; ++j)
+                playfield.grid.fillCell(i, j, grid[i][j]);
         return playfield;
     }
 
@@ -27,11 +28,11 @@ public class PlayfieldTest {
                                          {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
                                          {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
 
-        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
-                                         {0, 0, 0, 0, 0},
-                                         {0, 0, 1, 0, 0},
-                                         {0, 1, 1, 0, 0},
-                                         {0, 1, 0, 0, 0}};
+        var expectedGrid  = new Grid(new byte[][]{{0, 0, 0, 0, 0},
+                                                  {0, 0, 0, 0, 0},
+                                                  {0, 0, 1, 0, 0},
+                                                  {0, 1, 1, 0, 0},
+                                                  {0, 1, 0, 0, 0}});
 
         Block block = new ZBlock();
 
@@ -49,8 +50,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 2);
         sa.assertEquals(playfield.col, 1);
         sa.assertTrue(playfield.block instanceof RotatedBlock);
-        IntStream.range(0, playfield.row)
-                 .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
 
@@ -84,8 +84,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 2);
         sa.assertEquals(playfield.col, 1);
         sa.assertTrue(playfield.block instanceof RotatedBlock);
-        IntStream.range(0, playfield.row)
-                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
     
@@ -119,8 +118,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 1);
         sa.assertEquals(playfield.col, 1);
         sa.assertTrue(playfield.block instanceof RotatedBlock);
-        IntStream.range(0, playfield.row)
-                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
     
@@ -154,8 +152,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 1);
         sa.assertEquals(playfield.col, 1);
         sa.assertTrue(playfield.block instanceof RotatedBlock);
-        IntStream.range(0, playfield.row)
-                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
 
@@ -189,8 +186,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 3);
         sa.assertEquals(playfield.col, 1);
         sa.assertSame(playfield.block, block);
-        IntStream.range(0, playfield.row)
-                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
     
@@ -224,8 +220,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 2);
         sa.assertEquals(playfield.col, 3);
         sa.assertSame(playfield.block, block);
-        IntStream.range(0, playfield.row)
-                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
 
@@ -259,8 +254,7 @@ public class PlayfieldTest {
         sa.assertEquals(playfield.row, 1);
         sa.assertEquals(playfield.col, 1);
         sa.assertSame(playfield.block, block);
-        IntStream.range(0, playfield.row)
-                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertEquals(playfield.grid, expectedGrid);
         sa.assertAll();
     }
 }

--- a/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
@@ -1,0 +1,266 @@
+package com.epam.prejap.teatrees.game;
+
+import com.epam.prejap.teatrees.block.*;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.stream.IntStream;
+
+@Test
+public class PlayfieldTest {
+    private Playfield createPlayfield(byte[][] grid) {
+        Printer printer = new Printer(new PrintStream(new ByteArrayOutputStream()));
+        BlockFeed blockFeed = new BlockFeed();
+        Playfield playfield = new Playfield(grid.length, grid[0].length, blockFeed, printer);
+        for(int i = 0; i < grid.length; ++i)
+            System.arraycopy(grid[i], 0, playfield.grid[i], 0, grid[0].length);
+        return playfield;
+    }
+
+    public void rotateBlockInEmptySpace() {
+        // given
+        var playfieldGrid = new byte[][]{{0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 1, 1, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 1, 1, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
+
+        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0},
+                                         {0, 0, 1, 0, 0},
+                                         {0, 1, 1, 0, 0},
+                                         {0, 1, 0, 0, 0}};
+
+        Block block = new ZBlock();
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 1;
+        playfield.col   = 1;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertTrue(movedDown);
+        sa.assertEquals(playfield.row, 2);
+        sa.assertEquals(playfield.col, 1);
+        sa.assertTrue(playfield.block instanceof RotatedBlock);
+        IntStream.range(0, playfield.row)
+                 .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+
+    public void rotateBlockCloseToBottom() {
+        // given
+        var playfieldGrid = new byte[][]{{0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 1, 1, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 1, 1, 0}
+                                         {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
+
+        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0},
+                                         {0, 0, 1, 0, 0},
+                                         {0, 1, 1, 0, 0},
+                                         {0, 1, 0, 0, 0}};
+
+        Block block = new ZBlock();
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 2;
+        playfield.col   = 1;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertFalse(movedDown);
+        sa.assertEquals(playfield.row, 2);
+        sa.assertEquals(playfield.col, 1);
+        sa.assertTrue(playfield.block instanceof RotatedBlock);
+        IntStream.range(0, playfield.row)
+                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+    
+    public void rotateBlockCloseToLeftEdge() {
+        // given
+        var playfieldGrid = new byte[][]{{0, 0, 0, 0, 0},  // {1, 1, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 1, 1, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
+        
+        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
+                                         {0, 1, 0, 0, 0},
+                                         {1, 1, 0, 0, 0},
+                                         {1, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0}};
+
+        Block block = new ZBlock();
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 0;
+        playfield.col   = 1;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertTrue(movedDown);
+        sa.assertEquals(playfield.row, 1);
+        sa.assertEquals(playfield.col, 1);
+        sa.assertTrue(playfield.block instanceof RotatedBlock);
+        IntStream.range(0, playfield.row)
+                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+    
+    public void rotateBlockInLimitedSpace() {
+        // given
+        var playfieldGrid = new byte[][]{{2, 2, 2, 2, 2},  // {2, 2, 2, 2, 2}
+                                         {2, 0, 0, 2, 2},  // {2, 1, 1, 2, 2}
+                                         {2, 0, 0, 0, 2},  // {2, 0, 1, 1, 2}
+                                         {2, 0, 2, 2, 2},  // {2, 0, 2, 2, 2}
+                                         {2, 2, 2, 2, 2}}; // {2, 2, 2, 2, 2}
+        
+        var expectedGrid  = new byte[][]{{2, 2, 2, 2, 2},
+                                         {2, 0, 1, 2, 2},
+                                         {2, 1, 1, 0, 2},
+                                         {2, 1, 2, 2, 2},
+                                         {2, 2, 2, 2, 2}};
+
+        Block block = new ZBlock();
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 1;
+        playfield.col   = 1;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertFalse(movedDown);
+        sa.assertEquals(playfield.row, 1);
+        sa.assertEquals(playfield.col, 1);
+        sa.assertTrue(playfield.block instanceof RotatedBlock);
+        IntStream.range(0, playfield.row)
+                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+
+    public void rotateBlockTooCloseToBottom() {
+        // given
+        var playfieldGrid = new byte[][]{{0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 1, 1, 0, 0}
+                                         {0, 0, 0, 0, 0}}; // {0, 0, 1, 1, 0}
+
+        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0},
+                                         {0, 1, 1, 0, 0},
+                                         {0, 0, 1, 1, 0}};
+
+        Block block = new ZBlock();
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 3;
+        playfield.col   = 1;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertFalse(movedDown);
+        sa.assertEquals(playfield.row, 3);
+        sa.assertEquals(playfield.col, 1);
+        sa.assertSame(playfield.block, block);
+        IntStream.range(0, playfield.row)
+                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+    
+    public void rotateBlockTooCloseToRightEdge() {
+        // given
+        var playfieldGrid = new byte[][]{{0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 0, 1}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 1, 1}
+                                         {0, 0, 0, 0, 0},  // {0, 0, 0, 1, 0}
+                                         {0, 0, 0, 0, 0}}; // {0, 0, 0, 0, 0}
+
+        var expectedGrid  = new byte[][]{{0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 1},
+                                         {0, 0, 0, 1, 1},
+                                         {0, 0, 0, 1, 0}};
+
+        Block block = new RotatedBlock(new ZBlock());
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 1;
+        playfield.col   = 3;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertTrue(movedDown);
+        sa.assertEquals(playfield.row, 2);
+        sa.assertEquals(playfield.col, 3);
+        sa.assertSame(playfield.block, block);
+        IntStream.range(0, playfield.row)
+                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+
+    public void rotateBlockImpossible() {
+        // given
+        var playfieldGrid = new byte[][]{{2, 2, 2, 2, 2},  // {2, 2, 2, 2, 2}
+                                         {2, 0, 0, 2, 2},  // {2, 1, 1, 2, 2}
+                                         {2, 0, 0, 0, 2},  // {2, 0, 1, 1, 2}
+                                         {2, 2, 2, 2, 2},  // {2, 0, 2, 2, 2}
+                                         {2, 2, 2, 2, 2}}; // {2, 2, 2, 2, 2}
+
+        var expectedGrid  = new byte[][]{{2, 2, 2, 2, 2},
+                                         {2, 1, 1, 2, 2},
+                                         {2, 0, 1, 1, 2},
+                                         {2, 2, 2, 2, 2},
+                                         {2, 2, 2, 2, 2}};
+
+        Block block = new ZBlock();
+
+        Playfield playfield = createPlayfield(playfieldGrid);
+        playfield.block = block;
+        playfield.row   = 1;
+        playfield.col   = 1;
+
+        // when
+        boolean movedDown = playfield.move(Move.UP);
+
+        // then
+        SoftAssert sa = new SoftAssert();
+        sa.assertFalse(movedDown);
+        sa.assertEquals(playfield.row, 1);
+        sa.assertEquals(playfield.col, 1);
+        sa.assertSame(playfield.block, block);
+        IntStream.range(0, playfield.row)
+                .forEach(i -> sa.assertEquals(playfield.grid[i], expectedGrid[i]));
+        sa.assertAll();
+    }
+}

--- a/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
+++ b/src/test/java/com/epam/prejap/teatrees/game/PlayfieldTest.java
@@ -20,6 +20,11 @@ public class PlayfieldTest {
         return playfield;
     }
 
+    private Block mockedZBlock() {
+        return new MockedBlock(new byte[][]{{1, 1, 0},
+                                            {0, 1, 1}});
+    }
+
     public void rotateBlockInEmptySpace() {
         // given
         var playfieldGrid = new byte[][]{{0, 0, 0, 0, 0},  // {0, 0, 0, 0, 0}
@@ -34,7 +39,7 @@ public class PlayfieldTest {
                                                   {0, 1, 1, 0, 0},
                                                   {0, 1, 0, 0, 0}});
 
-        Block block = new ZBlock();
+        Block block = mockedZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
@@ -68,7 +73,7 @@ public class PlayfieldTest {
                                                   {0, 1, 1, 0, 0},
                                                   {0, 1, 0, 0, 0}});
 
-        Block block = new ZBlock();
+        Block block = mockedZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
@@ -102,7 +107,7 @@ public class PlayfieldTest {
                                                   {1, 0, 0, 0, 0},
                                                   {0, 0, 0, 0, 0}});
 
-        Block block = new ZBlock();
+        Block block = mockedZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
@@ -136,7 +141,7 @@ public class PlayfieldTest {
                                                   {2, 1, 2, 2, 2},
                                                   {2, 2, 2, 2, 2}});
 
-        Block block = new ZBlock();
+        Block block = mockedZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
@@ -170,7 +175,7 @@ public class PlayfieldTest {
                                                   {0, 1, 1, 0, 0},
                                                   {0, 0, 1, 1, 0}});
 
-        Block block = new ZBlock();
+        Block block = mockedZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
@@ -204,7 +209,7 @@ public class PlayfieldTest {
                                                   {0, 0, 0, 1, 1},
                                                   {0, 0, 0, 1, 0}});
 
-        Block block = new RotatedBlock(new ZBlock());
+        Block block = new RotatedBlock(mockedZBlock());
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;
@@ -238,7 +243,7 @@ public class PlayfieldTest {
                                                   {2, 2, 2, 2, 2},
                                                   {2, 2, 2, 2, 2}});
 
-        Block block = new ZBlock();
+        Block block = mockedZBlock();
 
         Playfield playfield = createPlayfield(playfieldGrid);
         playfield.block = block;

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -16,8 +16,10 @@
         </groups>
         <classes>
             <class name="com.epam.prejap.teatrees.block.ZBlockTest"/>
+            <class name="com.epam.prejap.teatrees.block.RotatedBlock"/>
             <class name="com.epam.prejap.teatrees.game.WaiterTest"/>
             <class name="com.epam.prejap.teatrees.game.GridTest"/>
+            <class name="com.epam.prejap.teatrees.game.PlayfieldTest"/>
             <class name="com.epam.prejap.teatrees.player.RandomPlayerTest"/>
             <class name="com.epam.prejap.teatrees.pause.PauseTest"/>
         </classes>


### PR DESCRIPTION
At least one block type must be public to test rotation in Playfield. My choice is Z-Block as it gives perfect opportunities to investigate rotations. I do not see any other simple solution that can be applied instead. I think that public Z-Block is better than making public constructor of Block (required for mocking). What do you think? 

Close #11 